### PR TITLE
feat(chat): autoscrolling; more message loading

### DIFF
--- a/src/_graphql/api.tsx
+++ b/src/_graphql/api.tsx
@@ -933,7 +933,7 @@ export type IdleGameCounterRealTimeSubscription = { __typename?: 'subscription_r
 
 export const GetChatMessagesDocument = gql`
     subscription GetChatMessages {
-  chat_messages(order_by: {timestamp: desc}, limit: 10) {
+  chat_messages(order_by: {timestamp: desc}, limit: 200) {
     timestamp
     id
     message

--- a/src/_graphql/idle-game-chat-messages-asc.graphql
+++ b/src/_graphql/idle-game-chat-messages-asc.graphql
@@ -1,5 +1,5 @@
 subscription GetChatMessages {
-  chat_messages(order_by: { timestamp: desc }, limit: 10) {
+  chat_messages(order_by: { timestamp: desc }, limit: 200) {
     timestamp
     id
     message

--- a/src/components/chat-submit.tsx
+++ b/src/components/chat-submit.tsx
@@ -1,10 +1,11 @@
 import { useMutation } from '@apollo/client';
-import { Box, Button, Input } from '@chakra-ui/react';
+import { Box, Button, Input, useColorModeValue } from '@chakra-ui/react';
 import React from 'react';
 import {
   SendNewMessageDocument,
   SendNewMessageMutation,
 } from '../_graphql/api';
+import { sideNavWidth } from './layout';
 
 export const ChatSubmit = () => {
   const [message, setMessage] = React.useState('');
@@ -21,8 +22,18 @@ export const ChatSubmit = () => {
     setMessage('');
   };
 
+  const bg = useColorModeValue('gray.200', 'gray.600');
+
   return (
-    <Box marginTop="auto" display="flex">
+    <Box
+      marginTop="auto"
+      display="flex"
+      position="absolute"
+      bottom="0"
+      padding="1"
+      width={sideNavWidth}
+      bgColor={bg}
+    >
       <Input
         placeholder="Type to chat..."
         value={message}
@@ -36,8 +47,8 @@ export const ChatSubmit = () => {
       <Button
         colorScheme="teal"
         size="xs"
-        height="100%"
-        marginLeft="1rem"
+        height="40px"
+        marginLeft="0.5rem"
         paddingLeft="1rem"
         paddingRight="1rem"
         onClick={(e) => {

--- a/src/game/game.tsx
+++ b/src/game/game.tsx
@@ -1,10 +1,10 @@
-import { Box } from "@chakra-ui/react";
-import { Application, Container } from "pixi.js";
-import React, { useEffect, useRef, useState } from "react";
-import { useResize } from "../containers/counter/responsive-canvas";
-import { IdleGameCountersRealTimeDescSubscription } from "../_graphql/api";
-import { InitializeCelestials } from "./generate";
-import { Star } from "./star";
+import { Box } from '@chakra-ui/react';
+import { Application, Container } from 'pixi.js';
+import React, { useEffect, useRef, useState } from 'react';
+import { useResize } from '../containers/counter/responsive-canvas';
+import { IdleGameCountersRealTimeDescSubscription } from '../_graphql/api';
+import { InitializeCelestials } from './generate';
+import { Star } from './star';
 
 export const Game = ({
   data,


### PR DESCRIPTION
Included in this PR:

- Autoscrolling behaviour for initial load of the chat log, and when new messages arrive through the subscription

![message-loading](https://user-images.githubusercontent.com/12142999/134046193-00e7c1f0-b777-41f9-aad9-e6f080ae6933.gif)

- Contextual user colouring (if you were the sender, the username will show up in a different colour):

![image](https://user-images.githubusercontent.com/12142999/134046404-2ad5aec6-cec5-438a-85ff-98c63a9bfb1f.png)
